### PR TITLE
Bumped boto3 to version 1.24.30 in Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.24.8
+boto3==1.24.30
 botocore==1.27.8
 jmespath==1.0.0
 python-dateutil==2.8.2


### PR DESCRIPTION
DescribePackage is required to run apply_package_configurations.py or you get "error! 'CodeArtifact' object has no attribute 'describe_package'". This was added in version 1.24.30 for boto3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
