### PR TITLE
Replace launch date from placeholder to actual date

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [AWS CodeArtifact](https://docs.aws.amazon.com/codeartifact/index.html) is a fully managed artifact repository service
 that makes it easy for organizations to securely store and share software packages used for application development. 
-On [launch date] we introduced a feature called “Package Origin Control” which allows customers to protect themselves 
+On Jul14 2022 we introduced a feature called “Package Origin Control” which allows customers to protect themselves 
 against “dependency substitution“ or 
 “[dependency confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)" attacks.
 


### PR DESCRIPTION
The launch date remained a placeholder. So I replaced this with the actual date based on the following blog.

https://aws.amazon.com/blogs/devops/tighten-your-package-security-with-codeartifact-package-origin-control-toolkit/
```
On Jul14 2022 we introduced a new feature called [Package Origin Controls](https://docs.aws.amazon.com/codeartifact/latest/ug/package-origin-controls.html) which allows customers to protect themselves against “dependency substitution“ or “[dependency confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)” attacks.
```